### PR TITLE
Disable align chained call

### DIFF
--- a/src/main/resources/jalopy.xml
+++ b/src/main/resources/jalopy.xml
@@ -111,7 +111,7 @@
    <printer>
     <alignment>
      <arrayInit>false</arrayInit>
-     <methodCallChain>true</methodCallChain>
+     <methodCallChain>false</methodCallChain>
      <nestedMethodCallChain>true</nestedMethodCallChain>
      <parameterMethodDeclaration>false</parameterMethodDeclaration>
      <ternaryOperator>true</ternaryOperator>


### PR DESCRIPTION
This it made in order to avoid something like 
```
		final Select.Where playlistEntitySelect = QueryBuilder
		        .select()
		                                                      .all()
		                                                      .from(PlaylistKeyspace.NAME, PlaylistFields.TABLE_NAME)
		                                                      .where(eq(PlaylistFields.OWNER_USER_ID, userId));
```

It now gets indented like: 
```
		final Select.Where playlistEntitySelect = QueryBuilder
		        .select()
		        .all()
		        .from(PlaylistKeyspace.NAME, PlaylistFields.TABLE_NAME)
		        .where(eq(PlaylistFields.OWNER_USER_ID, userId));
```